### PR TITLE
acceptance test - async error

### DIFF
--- a/tests/acceptance/index-test.js
+++ b/tests/acceptance/index-test.js
@@ -15,6 +15,7 @@ module('Acceptance | index', {
 });
 
 test('visiting /', function(assert) {
+  assert.expect(2);
   window.localStorage.clear('org.cubiq.addtohome');
   visit('/');
 


### PR DESCRIPTION
this acceptance test expects 2 assertions, and shouldn't pass unless it finds both (currently it won't pass).

There's something about the acceptance test setup that's leading the add-to-homescreen popup not to show.